### PR TITLE
Add interactive Transformer visualization (transformer-viz/)

### DIFF
--- a/transformer-viz/index.html
+++ b/transformer-viz/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Transformer Visualizer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<!-- ── Header ──────────────────────────────────────────────────────────────── -->
+<div id="header">
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#3b82f6" stroke-width="2.2">
+    <rect x="3" y="3" width="7" height="7" rx="1.5"/>
+    <rect x="14" y="3" width="7" height="7" rx="1.5"/>
+    <rect x="3" y="14" width="7" height="7" rx="1.5"/>
+    <rect x="14" y="14" width="7" height="7" rx="1.5"/>
+  </svg>
+  <div>
+    <h1>Transformer Visualizer</h1>
+    <div class="subtitle">"Attention Is All You Need" — encoder–decoder, step by step</div>
+  </div>
+</div>
+
+<div id="app">
+
+  <!-- ── Sidebar ────────────────────────────────────────────────────────── -->
+  <div id="sidebar">
+
+    <div id="input-section">
+      <label for="sentence-input">Input sentence (simple English words)</label>
+      <textarea id="sentence-input" placeholder="the cat sat on the mat">the cat sat on the mat</textarea>
+      <button id="run-btn">&#9654;&#xFE0E; Run Forward Pass</button>
+      <div id="unk-warning"></div>
+    </div>
+
+    <div id="token-display"></div>
+
+    <div id="step-controls">
+      <button class="nav-btn" id="prev-btn" disabled title="Previous step">&#8592;</button>
+      <div id="step-counter">Click Run to start</div>
+      <button class="nav-btn" id="next-btn" disabled title="Next step">&#8594;</button>
+    </div>
+
+    <div id="head-selector">
+      <span>Attn head:</span>
+      <button class="head-btn active" data-head="0">H0</button>
+      <button class="head-btn"        data-head="1">H1</button>
+      <button class="head-btn"        data-head="2">H2</button>
+      <button class="head-btn"        data-head="3">H3</button>
+    </div>
+
+    <div id="explanation-panel">
+      <div id="step-title">Welcome to the Transformer Visualizer</div>
+      <div id="step-description">
+        Type a sentence using common English words, then click
+        <strong>Run Forward Pass</strong> to step through the full
+        encoder–decoder Transformer. Use ← → to navigate between steps,
+        and switch attention heads with the H0–H3 buttons.
+      </div>
+      <pre id="step-formula">d_model = 64   n_heads = 4
+n_layers = 2   d_ff    = 256
+vocab    = 88 words</pre>
+    </div>
+
+  </div><!-- /sidebar -->
+
+  <!-- ── Canvas Area ─────────────────────────────────────────────────────── -->
+  <div id="canvas-area">
+    <div id="arch-and-heatmap">
+
+      <!-- Architecture SVG + token dot overlay -->
+      <div id="arch-container">
+
+        <svg id="arch-svg" width="560" height="680" viewBox="0 0 560 680"
+             xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <!-- Arrow markers -->
+            <marker id="arr" viewBox="0 0 8 8" refX="8" refY="4"
+                    markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+              <path d="M0,0 L8,4 L0,8 Z" fill="#475569"/>
+            </marker>
+            <marker id="arr-cross" viewBox="0 0 8 8" refX="8" refY="4"
+                    markerWidth="5" markerHeight="5" orient="auto-start-reverse">
+              <path d="M0,0 L8,4 L0,8 Z" fill="#7c3aed"/>
+            </marker>
+          </defs>
+
+          <!-- ════════════════════════════════════════════════════════════════
+               ENCODER  (x: 40–240, centre 140)
+               Flow: bottom → top   (y decreases going up)
+               ════════════════════════════════════════════════════════════════ -->
+          <text x="140" y="18" text-anchor="middle" font-size="12"
+                font-weight="700" fill="#3b82f6" font-family="monospace">ENCODER ×2</text>
+
+          <!-- Input token label -->
+          <text x="140" y="672" text-anchor="middle" font-size="10"
+                fill="#64748b" font-family="monospace">encoder input tokens</text>
+          <line x1="140" y1="661" x2="140" y2="648"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- enc-embed-box -->
+          <rect id="enc-embed-box" class="arch-box encoder"
+                x="55" y="618" width="170" height="28" rx="5"/>
+          <text x="140" y="636" text-anchor="middle" font-size="10"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Embed + Pos Enc</text>
+          <line x1="140" y1="618" x2="140" y2="606"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- ─── Encoder Layer 0 ─────────────────────────────────────── -->
+          <!-- enc-mha-0 -->
+          <rect id="enc-mha-0" class="arch-box encoder"
+                x="55" y="568" width="170" height="28" rx="4"/>
+          <text x="140" y="586" text-anchor="middle" font-size="9"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Multi-Head Self-Attn</text>
+          <line x1="140" y1="568" x2="140" y2="558"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- enc-addnorm-mha-0 -->
+          <rect id="enc-addnorm-mha-0" class="arch-box encoder"
+                x="55" y="530" width="170" height="22" rx="4"/>
+          <text x="140" y="545" text-anchor="middle" font-size="9"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <!-- residual skip: embed → addnorm-mha-0 -->
+          <path class="residual" d="M225,634 Q248,634 248,541 Q248,541 225,541"/>
+          <line x1="140" y1="530" x2="140" y2="518"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- enc-ffn-0 -->
+          <rect id="enc-ffn-0" class="arch-box encoder"
+                x="55" y="490" width="170" height="22" rx="4"/>
+          <text x="140" y="505" text-anchor="middle" font-size="9"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Feed-Forward (d_ff=256)</text>
+          <line x1="140" y1="490" x2="140" y2="478"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- enc-addnorm-ffn-0 -->
+          <rect id="enc-addnorm-ffn-0" class="arch-box encoder"
+                x="55" y="450" width="170" height="22" rx="4"/>
+          <text x="140" y="465" text-anchor="middle" font-size="9"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <!-- residual skip: addnorm-mha-0 → addnorm-ffn-0 -->
+          <path class="residual" d="M225,541 Q240,541 240,461 Q240,461 225,461"/>
+          <line x1="140" y1="450" x2="140" y2="438"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- ─── Encoder Layer 1 ─────────────────────────────────────── -->
+          <!-- enc-mha-1 -->
+          <rect id="enc-mha-1" class="arch-box encoder"
+                x="55" y="400" width="170" height="28" rx="4"/>
+          <text x="140" y="418" text-anchor="middle" font-size="9"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Multi-Head Self-Attn</text>
+          <line x1="140" y1="400" x2="140" y2="390"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- enc-addnorm-mha-1 -->
+          <rect id="enc-addnorm-mha-1" class="arch-box encoder"
+                x="55" y="362" width="170" height="22" rx="4"/>
+          <text x="140" y="377" text-anchor="middle" font-size="9"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <!-- residual: layer-0-top → addnorm-mha-1 -->
+          <path class="residual" d="M225,461 Q252,461 252,373 Q252,373 225,373"/>
+          <line x1="140" y1="362" x2="140" y2="350"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- enc-ffn-1 -->
+          <rect id="enc-ffn-1" class="arch-box encoder"
+                x="55" y="322" width="170" height="22" rx="4"/>
+          <text x="140" y="337" text-anchor="middle" font-size="9"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Feed-Forward (d_ff=256)</text>
+          <line x1="140" y1="322" x2="140" y2="310"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- enc-addnorm-ffn-1 -->
+          <rect id="enc-addnorm-ffn-1" class="arch-box encoder"
+                x="55" y="282" width="170" height="22" rx="4"/>
+          <text x="140" y="297" text-anchor="middle" font-size="9"
+                fill="#93c5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <path class="residual" d="M225,373 Q240,373 240,293 Q240,293 225,293"/>
+          <!-- Encoder output arrow + label -->
+          <line x1="140" y1="282" x2="140" y2="260"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+          <text x="140" y="252" text-anchor="middle" font-size="9"
+                fill="#64748b" font-family="monospace">encoder output (memory)</text>
+
+          <!-- ════════════════════════════════════════════════════════════════
+               DECODER  (x: 340–540, centre 440)
+               ════════════════════════════════════════════════════════════════ -->
+          <text x="440" y="18" text-anchor="middle" font-size="12"
+                font-weight="700" fill="#8b5cf6" font-family="monospace">DECODER ×2</text>
+
+          <!-- Output label -->
+          <text x="440" y="672" text-anchor="middle" font-size="10"
+                fill="#64748b" font-family="monospace">decoder input (&lt;sos&gt; + tokens)</text>
+          <line x1="440" y1="661" x2="440" y2="648"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-embed-box -->
+          <rect id="dec-embed-box" class="arch-box decoder"
+                x="355" y="618" width="170" height="28" rx="5"/>
+          <text x="440" y="636" text-anchor="middle" font-size="10"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Embed + Pos Enc</text>
+          <line x1="440" y1="618" x2="440" y2="606"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- ─── Decoder Layer 0 ─────────────────────────────────────── -->
+          <!-- dec-masked-mha-0 -->
+          <rect id="dec-masked-mha-0" class="arch-box decoder"
+                x="355" y="568" width="170" height="28" rx="4"/>
+          <text x="440" y="586" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Masked Self-Attn</text>
+          <line x1="440" y1="568" x2="440" y2="558"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-addnorm-mmha-0 -->
+          <rect id="dec-addnorm-mmha-0" class="arch-box decoder"
+                x="355" y="530" width="170" height="22" rx="4"/>
+          <text x="440" y="545" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <path class="residual" d="M525,634 Q548,634 548,541 Q548,541 525,541"/>
+          <line x1="440" y1="530" x2="440" y2="518"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-cross-mha-0 -->
+          <rect id="dec-cross-mha-0" class="arch-box decoder"
+                x="355" y="490" width="170" height="28" rx="4"/>
+          <text x="440" y="504" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Multi-Head Cross-Attn</text>
+          <text x="440" y="515" text-anchor="middle" font-size="8"
+                fill="#a78bfa" font-family="monospace" pointer-events="none">(Q←dec, K/V←enc)</text>
+          <line x1="440" y1="490" x2="440" y2="480"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-addnorm-cmha-0 -->
+          <rect id="dec-addnorm-cmha-0" class="arch-box decoder"
+                x="355" y="452" width="170" height="22" rx="4"/>
+          <text x="440" y="467" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <path class="residual" d="M525,541 Q550,541 550,463 Q550,463 525,463"/>
+          <line x1="440" y1="452" x2="440" y2="440"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-ffn-0 (implied — same layer, no separate highlight needed for step 8 walk) -->
+          <rect id="dec-ffn-0" class="arch-box decoder"
+                x="355" y="412" width="170" height="22" rx="4"/>
+          <text x="440" y="427" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Feed-Forward (d_ff=256)</text>
+          <line x1="440" y1="412" x2="440" y2="400"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-addnorm-ffn-0 -->
+          <rect id="dec-addnorm-ffn-0" class="arch-box decoder"
+                x="355" y="372" width="170" height="22" rx="4"/>
+          <text x="440" y="387" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <path class="residual" d="M525,463 Q542,463 542,383 Q542,383 525,383"/>
+          <line x1="440" y1="372" x2="440" y2="360"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- ─── Decoder Layer 1 ─────────────────────────────────────── -->
+          <!-- dec-masked-mha-1 -->
+          <rect id="dec-masked-mha-1" class="arch-box decoder"
+                x="355" y="322" width="170" height="28" rx="4"/>
+          <text x="440" y="340" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Masked Self-Attn</text>
+          <line x1="440" y1="322" x2="440" y2="312"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-addnorm-mmha-1 -->
+          <rect id="dec-addnorm-mmha-1" class="arch-box decoder"
+                x="355" y="284" width="170" height="22" rx="4"/>
+          <text x="440" y="299" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <path class="residual" d="M525,383 Q552,383 552,295 Q552,295 525,295"/>
+          <line x1="440" y1="284" x2="440" y2="272"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-cross-mha-1 -->
+          <rect id="dec-cross-mha-1" class="arch-box decoder"
+                x="355" y="244" width="170" height="28" rx="4"/>
+          <text x="440" y="258" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Multi-Head Cross-Attn</text>
+          <text x="440" y="269" text-anchor="middle" font-size="8"
+                fill="#a78bfa" font-family="monospace" pointer-events="none">(Q←dec, K/V←enc)</text>
+          <line x1="440" y1="244" x2="440" y2="234"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-addnorm-cmha-1 -->
+          <rect id="dec-addnorm-cmha-1" class="arch-box decoder"
+                x="355" y="206" width="170" height="22" rx="4"/>
+          <text x="440" y="221" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <path class="residual" d="M525,295 Q554,295 554,217 Q554,217 525,217"/>
+          <line x1="440" y1="206" x2="440" y2="194"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-ffn-1 -->
+          <rect id="dec-ffn-1" class="arch-box decoder"
+                x="355" y="166" width="170" height="22" rx="4"/>
+          <text x="440" y="181" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Feed-Forward (d_ff=256)</text>
+          <line x1="440" y1="166" x2="440" y2="154"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- dec-addnorm-ffn-1 -->
+          <rect id="dec-addnorm-ffn-1" class="arch-box decoder"
+                x="355" y="126" width="170" height="22" rx="4"/>
+          <text x="440" y="141" text-anchor="middle" font-size="9"
+                fill="#c4b5fd" font-family="monospace" pointer-events="none">Add &amp; Norm</text>
+          <path class="residual" d="M525,217 Q542,217 542,137 Q542,137 525,137"/>
+          <line x1="440" y1="126" x2="440" y2="114"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+
+          <!-- ─── Output ───────────────────────────────────────────────── -->
+          <!-- linear-softmax-box -->
+          <rect id="linear-softmax-box" class="arch-box output-box"
+                x="355" y="72" width="170" height="36" rx="5"/>
+          <text x="440" y="88" text-anchor="middle" font-size="10"
+                fill="#f0abfc" font-family="monospace" pointer-events="none">Linear + Softmax</text>
+          <text x="440" y="101" text-anchor="middle" font-size="8"
+                fill="#a78bfa" font-family="monospace" pointer-events="none">[seq × 88 vocab]</text>
+          <line x1="440" y1="72" x2="440" y2="54"
+                stroke="#475569" stroke-width="1.5" marker-end="url(#arr)"/>
+          <text x="440" y="46" text-anchor="middle" font-size="10"
+                fill="#64748b" font-family="monospace">output probabilities</text>
+
+          <!-- ════════════════════════════════════════════════════════════════
+               CROSS-ATTENTION ARROWS  (encoder memory → decoder)
+               Both cross-attn layers receive the same encoder output.
+               ════════════════════════════════════════════════════════════════ -->
+          <!-- Arrow to dec-cross-mha-0 (y centre ≈ 504) -->
+          <path id="cross-arrow-0" class="cross-arrow"
+                d="M225,268 Q290,268 290,504 Q290,504 355,504"
+                marker-end="url(#arr-cross)"/>
+
+          <!-- Arrow to dec-cross-mha-1 (y centre ≈ 258) -->
+          <path id="cross-arrow-1" class="cross-arrow"
+                d="M225,268 Q310,268 310,258 Q310,258 355,258"
+                marker-end="url(#arr-cross)"/>
+
+          <!-- Cross-arrow legend -->
+          <line x1="50" y1="36" x2="80" y2="36" stroke="#7c3aed"
+                stroke-width="1.5" stroke-dasharray="5 3"/>
+          <text x="84" y="40" font-size="9" fill="#64748b"
+                font-family="monospace">encoder→decoder (K, V)</text>
+
+        </svg><!-- /arch-svg -->
+
+        <!-- Token dot overlay — same viewport as arch-svg -->
+        <svg id="token-overlay" width="560" height="680"
+             viewBox="0 0 560 680" xmlns="http://www.w3.org/2000/svg"></svg>
+
+      </div><!-- /arch-container -->
+
+      <!-- Heatmap Panel -->
+      <div id="heatmap-area">
+        <div id="attn-container"></div>
+        <div id="qkv-area">
+          <div id="q-container"></div>
+          <div id="k-container"></div>
+          <div id="v-container"></div>
+        </div>
+      </div>
+
+    </div><!-- /arch-and-heatmap -->
+  </div><!-- /canvas-area -->
+
+</div><!-- /app -->
+
+<!-- Load order: D3 → math → viz -->
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="transformer.js"></script>
+<script src="viz.js"></script>
+</body>
+</html>

--- a/transformer-viz/style.css
+++ b/transformer-viz/style.css
@@ -1,0 +1,342 @@
+/* style.css — Transformer Visualization */
+
+:root {
+  --enc: #3b82f6;
+  --dec: #8b5cf6;
+  --attn: #f59e0b;
+  --ffn: #10b981;
+  --hl: #ef4444;
+  --dot: #f97316;
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface2: #334155;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: #334155;
+  --sidebar: 300px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────────── */
+#header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 18px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+#header h1 { font-size: 16px; font-weight: 700; }
+.subtitle   { font-size: 12px; color: var(--muted); margin-top: 1px; }
+
+/* ── App Layout ──────────────────────────────────────────────────────────────── */
+#app {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ── Sidebar ─────────────────────────────────────────────────────────────────── */
+#sidebar {
+  width: var(--sidebar);
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+
+#input-section {
+  padding: 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+#input-section label {
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  margin-bottom: 6px;
+}
+
+#sentence-input {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 13px;
+  padding: 8px 10px;
+  resize: none;
+  height: 58px;
+  font-family: inherit;
+}
+#sentence-input:focus { outline: none; border-color: var(--enc); }
+
+#run-btn {
+  width: 100%;
+  margin-top: 8px;
+  padding: 8px 0;
+  background: var(--enc);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .15s;
+}
+#run-btn:hover  { background: #2563eb; }
+#run-btn:active { transform: scale(.98); }
+
+#unk-warning {
+  margin-top: 6px;
+  font-size: 11px;
+  color: #fbbf24;
+  display: none;
+  line-height: 1.5;
+}
+
+/* ── Token Display ───────────────────────────────────────────────────────────── */
+#token-display {
+  display: none;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.token-row { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.token-label { font-size: 10px; color: var(--muted); width: 100%; margin-bottom: 2px; }
+.token {
+  display: inline-flex;
+  align-items: baseline;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.token sub { font-size: 8px; opacity: .7; margin-left: 2px; }
+.src-token { background: rgba(59,130,246,.18); color: #93c5fd; border: 1px solid rgba(59,130,246,.3); }
+.tgt-token { background: rgba(139,92,246,.18); color: #c4b5fd; border: 1px solid rgba(139,92,246,.3); }
+
+/* ── Step Controls ───────────────────────────────────────────────────────────── */
+#step-controls {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 34px 1fr 34px;
+  align-items: center;
+  gap: 6px;
+}
+
+.nav-btn {
+  width: 34px; height: 34px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 15px;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background .15s;
+}
+.nav-btn:hover:not(:disabled) { background: var(--border); }
+.nav-btn:disabled { opacity: .3; cursor: default; }
+
+#step-counter {
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* ── Head Selector ───────────────────────────────────────────────────────────── */
+#head-selector {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+#head-selector > span { font-size: 11px; color: var(--muted); margin-right: 2px; }
+
+.head-btn {
+  padding: 3px 9px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all .15s;
+}
+.head-btn:hover  { border-color: var(--attn); }
+.head-btn.active { background: var(--attn); border-color: var(--attn); color: #fff; font-weight: 600; }
+
+/* ── Explanation Panel ───────────────────────────────────────────────────────── */
+#explanation-panel {
+  padding: 14px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#step-title {
+  font-size: 13px;
+  font-weight: 700;
+  border-left: 3px solid var(--hl);
+  padding-left: 8px;
+  line-height: 1.4;
+}
+
+#step-description {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+#step-formula {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 11px;
+  color: #7dd3fc;
+  line-height: 1.9;
+  white-space: pre;
+  overflow-x: auto;
+}
+
+/* ── Canvas Area ─────────────────────────────────────────────────────────────── */
+#canvas-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+#arch-and-heatmap {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+#arch-container {
+  position: relative;
+  overflow: auto;
+  flex-shrink: 0;
+  background: var(--bg);
+}
+
+#arch-svg { display: block; }
+
+#token-overlay {
+  position: absolute;
+  top: 0; left: 0;
+  pointer-events: none;
+}
+
+/* ── SVG Box Styles ──────────────────────────────────────────────────────────── */
+.arch-box {
+  fill: #0f172a;
+  stroke-width: 1.5;
+  transition: fill .3s, opacity .3s, filter .3s, stroke .3s, stroke-width .3s;
+}
+.arch-box.encoder { stroke: var(--enc); }
+.arch-box.decoder { stroke: var(--dec); }
+.arch-box.output-box { stroke: #e879f9; }
+
+.arch-box.active {
+  fill: rgba(239,68,68,.12) !important;
+  stroke: var(--hl) !important;
+  stroke-width: 2.5 !important;
+  filter: drop-shadow(0 0 7px rgba(239,68,68,.55));
+}
+.arch-box.dimmed { opacity: .18; }
+
+.cross-arrow {
+  fill: none;
+  stroke: #7c3aed;
+  stroke-dasharray: 5 3;
+  transition: opacity .3s, filter .3s, stroke .3s;
+}
+.cross-arrow.active {
+  stroke: var(--hl);
+  filter: drop-shadow(0 0 5px rgba(239,68,68,.6));
+  opacity: 1 !important;
+}
+.cross-arrow.dimmed { opacity: .12; }
+
+.residual { fill: none; stroke: var(--surface2); stroke-dasharray: 3 2; }
+
+.flow-arrow { marker-end: url(#arr); }
+
+/* ── Token Dots ──────────────────────────────────────────────────────────────── */
+.token-dot {
+  filter: drop-shadow(0 0 3px rgba(249,115,22,.6));
+}
+
+/* ── Heatmap Area ────────────────────────────────────────────────────────────── */
+#heatmap-area {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 10px;
+  display: none;
+  flex-direction: column;
+  gap: 10px;
+  border-left: 1px solid var(--border);
+  background: var(--bg);
+  min-width: 220px;
+}
+#heatmap-area.visible {
+  display: flex;
+  animation: slideIn .25s ease;
+}
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateX(16px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+#attn-container, #q-container, #k-container, #v-container {
+  background: var(--surface);
+  border-radius: 8px;
+  padding: 8px;
+  overflow: auto;
+}
+
+#qkv-area {
+  display: none;
+  gap: 8px;
+}
+#qkv-area > div { flex: 1; min-width: 90px; }
+
+#heatmap-area text { font-family: monospace; }
+
+/* ── Scrollbars ──────────────────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 5px; height: 5px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--surface2); }
+
+/* ── Responsive ──────────────────────────────────────────────────────────────── */
+@media (max-width: 860px) {
+  #app { flex-direction: column; }
+  #sidebar { width: 100%; max-height: 260px; border-right: none; border-bottom: 1px solid var(--border); }
+}

--- a/transformer-viz/transformer.js
+++ b/transformer-viz/transformer.js
@@ -1,0 +1,355 @@
+// transformer.js — Pure math: TransformerModel, Tokenizer, ForwardTrace
+// No DOM access. Exports via window globals for file:// compatibility.
+
+// ─── Seeded PRNG (Mulberry32) ─────────────────────────────────────────────────
+function mulberry32(seed) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ─── Model Config ─────────────────────────────────────────────────────────────
+const CONFIG = {
+  d_model: 64,
+  n_heads: 4,
+  d_k: 16,
+  d_v: 16,
+  n_layers: 2,
+  d_ff: 256,
+  max_seq_len: 16,
+  vocab_size: 88,
+};
+
+// ─── Fixed Vocabulary ─────────────────────────────────────────────────────────
+const FIXED_VOCAB = [
+  '<pad>', '<sos>', '<eos>', '<unk>',
+  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'have', 'has',
+  'do', 'does', 'will', 'would', 'can', 'could', 'may', 'might', 'shall',
+  'should', 'must', 'not', 'no', 'yes', 'i', 'you', 'he', 'she', 'it', 'we',
+  'they', 'this', 'that', 'which', 'who', 'what', 'where', 'when', 'how',
+  'why', 'all', 'some', 'any', 'each', 'every', 'my', 'your', 'his', 'her',
+  'its', 'our', 'their', 'of', 'in', 'on', 'at', 'to', 'for', 'with', 'by',
+  'from', 'up', 'about', 'into', 'through', 'and', 'or', 'but', 'if',
+  'because', 'as', 'until', 'while', 'cat', 'dog', 'sat', 'mat', 'ran',
+  'fast', 'slow', 'big', 'small',
+];
+
+// ─── Math Primitives ──────────────────────────────────────────────────────────
+
+function matMul(A, B) {
+  // A: [m,k] as Array<Float32Array>, B: [k,n]  →  [m,n]
+  const m = A.length, k = B.length, n = B[0].length;
+  const C = [];
+  for (let i = 0; i < m; i++) {
+    C[i] = new Float32Array(n);
+    for (let l = 0; l < k; l++) {
+      const aVal = A[i][l];
+      for (let j = 0; j < n; j++) C[i][j] += aVal * B[l][j];
+    }
+  }
+  return C;
+}
+
+function addVec(a, b) {
+  const c = new Float32Array(a.length);
+  for (let i = 0; i < a.length; i++) c[i] = a[i] + b[i];
+  return c;
+}
+
+function softmax(v) {
+  let max = v[0];
+  for (let i = 1; i < v.length; i++) if (v[i] > max) max = v[i];
+  const out = new Float32Array(v.length);
+  let sum = 0;
+  for (let i = 0; i < v.length; i++) { out[i] = Math.exp(v[i] - max); sum += out[i]; }
+  for (let i = 0; i < v.length; i++) out[i] /= sum;
+  return out;
+}
+
+function layerNorm(x, gamma, beta, eps = 1e-6) {
+  const n = x.length;
+  let mean = 0;
+  for (let i = 0; i < n; i++) mean += x[i];
+  mean /= n;
+  let variance = 0;
+  for (let i = 0; i < n; i++) variance += (x[i] - mean) ** 2;
+  variance /= n;
+  const std = Math.sqrt(variance + eps);
+  const out = new Float32Array(n);
+  for (let i = 0; i < n; i++) out[i] = gamma[i] * (x[i] - mean) / std + beta[i];
+  return out;
+}
+
+function gelu(x) {
+  return 0.5 * x * (1 + Math.tanh(Math.sqrt(2 / Math.PI) * (x + 0.044715 * x * x * x)));
+}
+
+function scaledDotProductAttention(Q, K, V, mask) {
+  // Q:[seqQ,dk], K:[seqK,dk], V:[seqK,dv], mask:[seqQ][seqK]|null
+  const seqQ = Q.length, seqK = K.length, dk = Q[0].length, dv = V[0].length;
+  const scale = 1 / Math.sqrt(dk);
+
+  const scores = [];
+  for (let i = 0; i < seqQ; i++) {
+    scores[i] = new Float32Array(seqK);
+    for (let j = 0; j < seqK; j++) {
+      let dot = 0;
+      for (let d = 0; d < dk; d++) dot += Q[i][d] * K[j][d];
+      scores[i][j] = dot * scale;
+      if (mask && mask[i][j]) scores[i][j] = -1e9;
+    }
+  }
+
+  const weights = [];
+  for (let i = 0; i < seqQ; i++) weights[i] = softmax(scores[i]);
+
+  const output = [];
+  for (let i = 0; i < seqQ; i++) {
+    output[i] = new Float32Array(dv);
+    for (let j = 0; j < seqK; j++) {
+      const w = weights[i][j];
+      for (let d = 0; d < dv; d++) output[i][d] += w * V[j][d];
+    }
+  }
+
+  return { output, weights };
+}
+
+function buildCausalMask(seqLen) {
+  const mask = [];
+  for (let i = 0; i < seqLen; i++) {
+    mask[i] = new Array(seqLen);
+    for (let j = 0; j < seqLen; j++) mask[i][j] = j > i;
+  }
+  return mask;
+}
+
+// ─── Tokenizer ────────────────────────────────────────────────────────────────
+
+class Tokenizer {
+  constructor() {
+    this.id2word = [...FIXED_VOCAB];
+    this.word2id = {};
+    FIXED_VOCAB.forEach((w, i) => { this.word2id[w] = i; });
+  }
+
+  encode(sentence) {
+    return sentence
+      .toLowerCase()
+      .replace(/[^a-z\s]/g, '')
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, CONFIG.max_seq_len - 2)
+      .map(w => (this.word2id[w] !== undefined ? this.word2id[w] : this.word2id['<unk>']));
+  }
+
+  decode(ids) {
+    return ids.map(id => this.id2word[id] || '<unk>').join(' ');
+  }
+
+  getUnknownWords(sentence) {
+    return sentence
+      .toLowerCase()
+      .replace(/[^a-z\s]/g, '')
+      .split(/\s+/)
+      .filter(w => w && this.word2id[w] === undefined);
+  }
+}
+
+// ─── Weight Helpers ───────────────────────────────────────────────────────────
+
+function initMatrix(rows, cols, rng, scale) {
+  const M = [];
+  for (let i = 0; i < rows; i++) {
+    M[i] = new Float32Array(cols);
+    for (let j = 0; j < cols; j++) M[i][j] = (rng() * 2 - 1) * scale;
+  }
+  return M;
+}
+
+function initVec(len, val) {
+  const v = new Float32Array(len);
+  v.fill(val);
+  return v;
+}
+
+// ─── TransformerModel ─────────────────────────────────────────────────────────
+
+class TransformerModel {
+  constructor() {
+    const rng = mulberry32(42);
+    const { d_model, n_heads, d_k, d_v, n_layers, d_ff, vocab_size, max_seq_len } = CONFIG;
+    const eS = Math.sqrt(2 / d_model);
+    const fS = Math.sqrt(2 / d_ff);
+
+    // Shared embedding matrix [vocab, d_model]
+    this.embedWeight = initMatrix(vocab_size, d_model, rng, eS);
+
+    // Sinusoidal positional encoding (deterministic, not random)
+    this.posEncoding = [];
+    for (let pos = 0; pos < max_seq_len; pos++) {
+      this.posEncoding[pos] = new Float32Array(d_model);
+      for (let i = 0; i < d_model; i += 2) {
+        const angle = pos / Math.pow(10000, i / d_model);
+        this.posEncoding[pos][i]     = Math.sin(angle);
+        if (i + 1 < d_model) this.posEncoding[pos][i + 1] = Math.cos(angle);
+      }
+    }
+
+    const makeHeads = () => {
+      const h = { Wq: [], Wk: [], Wv: [] };
+      for (let i = 0; i < n_heads; i++) {
+        h.Wq[i] = initMatrix(d_model, d_k, rng, eS);
+        h.Wk[i] = initMatrix(d_model, d_k, rng, eS);
+        h.Wv[i] = initMatrix(d_model, d_v, rng, eS);
+      }
+      h.Wo = initMatrix(n_heads * d_v, d_model, rng, eS);
+      return h;
+    };
+
+    const makeFFN = () => ({
+      W1: initMatrix(d_model, d_ff, rng, eS),
+      b1: initVec(d_ff, 0),
+      W2: initMatrix(d_ff, d_model, rng, fS),
+      b2: initVec(d_model, 0),
+    });
+
+    const makeNorm = () => ({ gamma: initVec(d_model, 1), beta: initVec(d_model, 0) });
+
+    // Encoder layers
+    this.encoderLayers = [];
+    for (let l = 0; l < n_layers; l++) {
+      this.encoderLayers[l] = { mha: makeHeads(), norm1: makeNorm(), norm2: makeNorm(), ffn: makeFFN() };
+    }
+
+    // Decoder layers
+    this.decoderLayers = [];
+    for (let l = 0; l < n_layers; l++) {
+      this.decoderLayers[l] = {
+        maskedMha: makeHeads(),
+        crossMha:  makeHeads(),
+        norm1: makeNorm(), norm2: makeNorm(), norm3: makeNorm(),
+        ffn: makeFFN(),
+      };
+    }
+
+    // Output projection [d_model, vocab_size]
+    this.outputProjection = initMatrix(d_model, vocab_size, rng, eS);
+  }
+
+  _embed(ids) {
+    const scale = Math.sqrt(CONFIG.d_model);
+    return ids.map(id => {
+      const row = new Float32Array(CONFIG.d_model);
+      for (let d = 0; d < CONFIG.d_model; d++) row[d] = this.embedWeight[id][d] * scale;
+      return row;
+    });
+  }
+
+  _addPosEnc(embeddings) {
+    return embeddings.map((emb, pos) => addVec(emb, this.posEncoding[pos]));
+  }
+
+  _multiHeadAttention(Q_in, K_in, V_in, W, mask) {
+    const { n_heads, d_v } = CONFIG;
+    const seqQ = Q_in.length;
+    const concat = Q_in.map(() => new Float32Array(n_heads * d_v));
+    const heads = [];
+
+    for (let h = 0; h < n_heads; h++) {
+      const Q = matMul(Q_in, W.Wq[h]);
+      const K = matMul(K_in, W.Wk[h]);
+      const V = matMul(V_in, W.Wv[h]);
+      const { output, weights } = scaledDotProductAttention(Q, K, V, mask);
+      heads.push({ Q, K, V, weights, output });
+      for (let i = 0; i < seqQ; i++)
+        for (let d = 0; d < d_v; d++) concat[i][h * d_v + d] = output[i][d];
+    }
+
+    const projected = matMul(concat, W.Wo);
+    return { heads, concat, projected };
+  }
+
+  _ffn(x, W) {
+    const { d_ff, d_model } = CONFIG;
+    const hidden = matMul(x, W.W1).map(row => {
+      const h = new Float32Array(d_ff);
+      for (let d = 0; d < d_ff; d++) h[d] = gelu(row[d] + W.b1[d]);
+      return h;
+    });
+    const output = matMul(hidden, W.W2).map(row => {
+      const o = new Float32Array(d_model);
+      for (let d = 0; d < d_model; d++) o[d] = row[d] + W.b2[d];
+      return o;
+    });
+    return { hidden, output };
+  }
+
+  forward(inputIds, targetIds) {
+    const { n_layers } = CONFIG;
+    const trace = { enc: { layers: [] }, dec: { layers: [] }, output: {} };
+
+    // ── Encoder ──────────────────────────────────────────────────────────────
+    trace.enc.inputIds   = inputIds;
+    trace.enc.embeddings = this._embed(inputIds);
+    trace.enc.withPosEnc = this._addPosEnc(trace.enc.embeddings);
+
+    let encX = trace.enc.withPosEnc;
+    for (let l = 0; l < n_layers; l++) {
+      const L = this.encoderLayers[l], lt = {};
+
+      lt.mha = this._multiHeadAttention(encX, encX, encX, L.mha, null);
+      const postMha = encX.map((row, i) => addVec(row, lt.mha.projected[i]));
+      lt.afterMhaNorm = postMha.map(r => layerNorm(r, L.norm1.gamma, L.norm1.beta));
+
+      lt.ffn = this._ffn(lt.afterMhaNorm, L.ffn);
+      const postFfn = lt.afterMhaNorm.map((row, i) => addVec(row, lt.ffn.output[i]));
+      lt.afterFfnNorm = postFfn.map(r => layerNorm(r, L.norm2.gamma, L.norm2.beta));
+
+      trace.enc.layers.push(lt);
+      encX = lt.afterFfnNorm;
+    }
+    trace.enc.output = encX;
+
+    // ── Decoder ──────────────────────────────────────────────────────────────
+    trace.dec.inputIds   = targetIds;
+    trace.dec.embeddings = this._embed(targetIds);
+    trace.dec.withPosEnc = this._addPosEnc(trace.dec.embeddings);
+
+    let decX = trace.dec.withPosEnc;
+    for (let l = 0; l < n_layers; l++) {
+      const L = this.decoderLayers[l], lt = {};
+      const causalMask = buildCausalMask(targetIds.length);
+
+      lt.maskedMha = this._multiHeadAttention(decX, decX, decX, L.maskedMha, causalMask);
+      const postMM = decX.map((row, i) => addVec(row, lt.maskedMha.projected[i]));
+      lt.afterMaskedNorm = postMM.map(r => layerNorm(r, L.norm1.gamma, L.norm1.beta));
+
+      lt.crossMha = this._multiHeadAttention(lt.afterMaskedNorm, trace.enc.output, trace.enc.output, L.crossMha, null);
+      const postCM = lt.afterMaskedNorm.map((row, i) => addVec(row, lt.crossMha.projected[i]));
+      lt.afterCrossNorm = postCM.map(r => layerNorm(r, L.norm2.gamma, L.norm2.beta));
+
+      lt.ffn = this._ffn(lt.afterCrossNorm, L.ffn);
+      const postFfn = lt.afterCrossNorm.map((row, i) => addVec(row, lt.ffn.output[i]));
+      lt.afterFfnNorm = postFfn.map(r => layerNorm(r, L.norm3.gamma, L.norm3.beta));
+
+      trace.dec.layers.push(lt);
+      decX = lt.afterFfnNorm;
+    }
+
+    // ── Output projection + softmax ───────────────────────────────────────────
+    trace.output.logits = matMul(decX, this.outputProjection);
+    trace.output.probs  = trace.output.logits.map(row => softmax(row));
+
+    return trace;
+  }
+}
+
+// ─── Globals ──────────────────────────────────────────────────────────────────
+window.TransformerModel  = TransformerModel;
+window.Tokenizer         = Tokenizer;
+window.TRANSFORMER_CONFIG = CONFIG;
+window.TRANSFORMER_VOCAB  = FIXED_VOCAB;

--- a/transformer-viz/viz.js
+++ b/transformer-viz/viz.js
@@ -1,0 +1,515 @@
+// viz.js — VizController: STEPS, D3 heatmaps, token animation, highlight logic
+// Reads window.TransformerModel, window.Tokenizer (set by transformer.js)
+
+// ─── Step Definitions ────────────────────────────────────────────────────────
+const STEPS = [
+  {
+    id: 'input',
+    title: '1 · Tokenization',
+    description: 'The input sentence is split into words. Each word is mapped to an integer ID from the 88-word vocabulary. Unknown words become &lt;unk&gt; (ID 3).',
+    formula: 'tokens = sentence.lower().split()\nids    = [vocab[t] for t in tokens]',
+    highlight: ['enc-embed-box'],
+    showHeatmap: false,
+  },
+  {
+    id: 'enc-embed',
+    title: '2 · Input Embedding + Positional Encoding',
+    description: 'Each token ID is looked up in the embedding matrix (d_model=64). A sinusoidal positional encoding is added elementwise so the model knows the order of tokens.',
+    formula: 'x  = EmbedMatrix[id] · √d_model\nx += PE(pos)\nPE(pos,2i)   = sin(pos / 10000^(2i/d))\nPE(pos,2i+1) = cos(pos / 10000^(2i/d))',
+    highlight: ['enc-embed-box'],
+    showHeatmap: true,
+    heatmapTarget: 'enc-embed',
+    traceKey: 'enc.withPosEnc',
+  },
+  {
+    id: 'enc-mha-0',
+    title: '3 · Encoder Self-Attention (Layer 1)',
+    description: 'Each token attends to every other encoder token. For each head, Q/K/V are projected (d_k=16). Attention weights = softmax(QKᵀ / √d_k). Four heads run in parallel then concatenated.',
+    formula: 'Q = X·Wq,  K = X·Wk,  V = X·Wv\nAttn = softmax(Q·Kᵀ / √d_k) · V\nout  = Concat(head₁…h₄) · Wₒ',
+    highlight: ['enc-mha-0', 'enc-addnorm-mha-0'],
+    showHeatmap: true,
+    heatmapTarget: 'mha',
+    layerIndex: 0,
+    traceKey: 'enc.layers.0.mha',
+    isEncoder: true,
+  },
+  {
+    id: 'enc-ffn-0',
+    title: '4 · Encoder Feed-Forward Network (Layer 1)',
+    description: 'Each position is processed independently by a 2-layer MLP with GELU activation. The hidden dimension expands 4× to 256 then projects back to d_model=64. Residual + LayerNorm applied after.',
+    formula: 'FFN(x) = GELU(x·W₁ + b₁) · W₂ + b₂\nd_ff = 256  →  project back to 64',
+    highlight: ['enc-ffn-0', 'enc-addnorm-ffn-0'],
+    showHeatmap: false,
+  },
+  {
+    id: 'enc-layer-1',
+    title: '5 · Encoder Layer 2 (Self-Attention + FFN)',
+    description: 'The second encoder layer repeats the same operations, building deeper contextual representations. Each sub-layer wraps its output: out = LayerNorm(x + Sublayer(x)).',
+    formula: 'y = LayerNorm(x + SelfAttn(x))\nz = LayerNorm(y + FFN(y))\n(×2 layers total)',
+    highlight: ['enc-mha-1', 'enc-addnorm-mha-1', 'enc-ffn-1', 'enc-addnorm-ffn-1'],
+    showHeatmap: true,
+    heatmapTarget: 'mha',
+    layerIndex: 1,
+    traceKey: 'enc.layers.1.mha',
+    isEncoder: true,
+  },
+  {
+    id: 'dec-embed',
+    title: '6 · Decoder Input Embedding + Positional Encoding',
+    description: 'The decoder receives the target sequence shifted right (starting with &lt;sos&gt;). The same embedding table and sinusoidal positional encoding are used.',
+    formula: 'y  = EmbedMatrix[tgt_id] · √d_model\ny += PE(pos)',
+    highlight: ['dec-embed-box'],
+    showHeatmap: false,
+  },
+  {
+    id: 'dec-masked-mha-0',
+    title: '7 · Decoder Masked Self-Attention (Layer 1)',
+    description: 'The decoder attends only to previous output tokens. A causal (lower-triangular) mask sets future positions to −∞ before softmax, so each position only sees what came before it.',
+    formula: 'mask[i,j] = −∞  if j > i,  else 0\nAttn = softmax((Q·Kᵀ + mask) / √d_k) · V',
+    highlight: ['dec-masked-mha-0', 'dec-addnorm-mmha-0'],
+    showHeatmap: true,
+    heatmapTarget: 'masked-mha',
+    layerIndex: 0,
+    traceKey: 'dec.layers.0.maskedMha',
+    isEncoder: false,
+  },
+  {
+    id: 'dec-cross-mha-0',
+    title: '8 · Decoder Cross-Attention (Layer 1)',
+    description: 'Q comes from the decoder, K and V come from the encoder output. This is how the decoder "reads" the encoded source — each decoder position can attend to all encoder positions.',
+    formula: 'Q = DecX·Wq\nK = EncOut·Wk,  V = EncOut·Wv\nAttn = softmax(Q·Kᵀ / √d_k) · V',
+    highlight: ['dec-cross-mha-0', 'dec-addnorm-cmha-0', 'cross-arrow-0', 'cross-arrow-1'],
+    showHeatmap: true,
+    heatmapTarget: 'cross-mha',
+    layerIndex: 0,
+    traceKey: 'dec.layers.0.crossMha',
+    isEncoder: false,
+  },
+  {
+    id: 'dec-layer-1',
+    title: '9 · Decoder Layer 2 (Masked Attn + Cross-Attn + FFN)',
+    description: 'Layer 2 repeats the same three sub-layers: masked self-attention, cross-attention (again reading from encoder), and FFN. Richer representations are built.',
+    formula: 'a = LayerNorm(x + MaskedAttn(x))\nb = LayerNorm(a + CrossAttn(a, enc))\nz = LayerNorm(b + FFN(b))',
+    highlight: ['dec-masked-mha-1', 'dec-addnorm-mmha-1', 'dec-cross-mha-1', 'dec-addnorm-cmha-1', 'dec-ffn-1', 'dec-addnorm-ffn-1'],
+    showHeatmap: true,
+    heatmapTarget: 'cross-mha',
+    layerIndex: 1,
+    traceKey: 'dec.layers.1.crossMha',
+    isEncoder: false,
+  },
+  {
+    id: 'output-proj',
+    title: '10 · Linear Projection + Softmax',
+    description: 'The final decoder representation is projected from d_model=64 to vocab_size=88 via a linear layer. Softmax converts logits to a probability distribution over the vocabulary for each output position.',
+    formula: 'logits = DecOut · W_out   [seq × 88]\nprobs  = softmax(logits,  dim=−1)',
+    highlight: ['linear-softmax-box'],
+    showHeatmap: true,
+    heatmapTarget: 'output-probs',
+    traceKey: 'output.probs',
+  },
+  {
+    id: 'summary',
+    title: '11 · Summary: Full Forward Pass Complete',
+    description: 'All layers have run. Each decoder position has a probability distribution over the vocabulary. In autoregressive decoding the model picks the next token (argmax or beam search) and feeds it back in.',
+    formula: 'next_token = argmax(probs[−1])\n\nEncoder:  embed → 2×(SelfAttn+FFN)\nDecoder:  embed → 2×(MskAttn+CrossAttn+FFN)\n          → Linear+Softmax',
+    highlight: [],
+    showHeatmap: false,
+    highlightAll: true,
+  },
+];
+
+// ─── Utility: resolve 'enc.layers.0.mha' → trace.enc.layers[0].mha ────────────
+function resolvePath(obj, path) {
+  return path.split('.').reduce((o, key) => {
+    if (o == null) return undefined;
+    const n = Number(key);
+    return Number.isInteger(n) ? o[n] : o[key];
+  }, obj);
+}
+
+// ─── VizController ────────────────────────────────────────────────────────────
+class VizController {
+  constructor() {
+    this.tokenizer = new window.Tokenizer();
+    this.model     = new window.TransformerModel();
+    this.trace     = null;
+    this.currentStep = 0;
+    this.currentHead = 0;
+    this.isAnimating = false;
+    this.srcTokens   = [];
+    this.tgtTokens   = [];
+    this.tokenDots   = [];
+    this.boxCenters  = {};
+
+    this._bindDOM();
+    // Compute box centers after a brief paint so getBBox() has layout
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => this._computeBoxCenters());
+    });
+  }
+
+  // ── DOM Binding ──────────────────────────────────────────────────────────────
+  _bindDOM() {
+    this.runBtn       = document.getElementById('run-btn');
+    this.prevBtn      = document.getElementById('prev-btn');
+    this.nextBtn      = document.getElementById('next-btn');
+    this.stepCounter  = document.getElementById('step-counter');
+    this.inputEl      = document.getElementById('sentence-input');
+    this.stepTitle    = document.getElementById('step-title');
+    this.stepDesc     = document.getElementById('step-description');
+    this.stepFormula  = document.getElementById('step-formula');
+    this.heatmapArea  = document.getElementById('heatmap-area');
+    this.attnContainer = document.getElementById('attn-container');
+    this.qkvArea      = document.getElementById('qkv-area');
+    this.qContainer   = document.getElementById('q-container');
+    this.kContainer   = document.getElementById('k-container');
+    this.vContainer   = document.getElementById('v-container');
+    this.tokenDisplay = document.getElementById('token-display');
+    this.archSvg      = document.getElementById('arch-svg');
+    this.overlay      = document.getElementById('token-overlay');
+    this.headBtns     = Array.from(document.querySelectorAll('.head-btn'));
+
+    this.runBtn.addEventListener('click', () => this._onRun());
+    this.prevBtn.addEventListener('click', () => this._onPrev());
+    this.nextBtn.addEventListener('click', () => this._onNext());
+    this.inputEl.addEventListener('keydown', e => {
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) this._onRun();
+    });
+    this.headBtns.forEach((btn, h) => btn.addEventListener('click', () => this._onHeadSelect(h)));
+  }
+
+  _computeBoxCenters() {
+    this.archSvg.querySelectorAll('.arch-box, .cross-arrow').forEach(el => {
+      if (!el.id) return;
+      try {
+        const b = el.getBBox();
+        this.boxCenters[el.id] = { x: b.x + b.width / 2, y: b.y + b.height / 2 };
+      } catch (_) {}
+    });
+  }
+
+  // ── Event Handlers ────────────────────────────────────────────────────────────
+  _onRun() {
+    const sentence = this.inputEl.value.trim();
+    if (!sentence) return;
+
+    const unknowns  = this.tokenizer.getUnknownWords(sentence);
+    const inputIds  = this.tokenizer.encode(sentence);
+
+    if (inputIds.length === 0) {
+      this.stepDesc.textContent = 'No recognizable words. Try: "the cat sat on the mat"';
+      return;
+    }
+
+    const SOS_ID   = 1;
+    const targetIds = [SOS_ID, ...inputIds.slice(0, 14)];
+
+    this.srcTokens = inputIds.map(id => window.TRANSFORMER_VOCAB[id]);
+    this.tgtTokens = targetIds.map(id => window.TRANSFORMER_VOCAB[id]);
+
+    const warn = document.getElementById('unk-warning');
+    if (unknowns.length > 0) {
+      warn.textContent = `Mapped to <unk>: ${unknowns.join(', ')}`;
+      warn.style.display = 'block';
+    } else {
+      warn.style.display = 'none';
+    }
+
+    this.trace = this.model.forward(inputIds, targetIds);
+    this.currentStep = 0;
+    this._renderStep(0);
+    this._createTokenDots();
+  }
+
+  _onPrev() {
+    if (this.isAnimating || this.currentStep === 0) return;
+    this.currentStep--;
+    this._renderStep(this.currentStep);
+  }
+
+  _onNext() {
+    if (this.isAnimating || this.currentStep >= STEPS.length - 1) return;
+    this.currentStep++;
+    this._renderStep(this.currentStep);
+  }
+
+  _onHeadSelect(h) {
+    this.currentHead = h;
+    this.headBtns.forEach((btn, i) => btn.classList.toggle('active', i === h));
+    if (this.trace) this._updateHeatmaps(this.currentStep);
+  }
+
+  // ── Rendering ─────────────────────────────────────────────────────────────────
+  _renderStep(idx) {
+    this.isAnimating = true;
+    this._setButtonsDisabled(true);
+
+    const step = STEPS[idx];
+    this.stepTitle.textContent  = step.title;
+    this.stepDesc.innerHTML     = step.description;
+    this.stepFormula.textContent = step.formula;
+    this.stepCounter.textContent = `Step ${idx + 1} / ${STEPS.length}`;
+
+    if (idx === 0 && this.trace) this._renderTokenDisplay();
+
+    this._updateArchHighlight(idx);
+    this._updateHeatmaps(idx);
+    this._moveDotsToStep(idx);
+
+    setTimeout(() => {
+      this.isAnimating = false;
+      this._setButtonsDisabled(false);
+    }, 450);
+  }
+
+  _setButtonsDisabled(d) {
+    this.prevBtn.disabled = d || this.currentStep === 0;
+    this.nextBtn.disabled = d || this.currentStep >= STEPS.length - 1;
+  }
+
+  _renderTokenDisplay() {
+    const src = this.srcTokens.map((t, i) =>
+      `<span class="token src-token">${t}<sub>${this.trace.enc.inputIds[i]}</sub></span>`
+    ).join('');
+    const tgt = this.tgtTokens.map((t, i) =>
+      `<span class="token tgt-token">${t}<sub>${this.trace.dec.inputIds[i]}</sub></span>`
+    ).join('');
+    this.tokenDisplay.innerHTML =
+      `<div class="token-row"><span class="token-label">Encoder input:</span>${src}</div>` +
+      `<div class="token-row"><span class="token-label">Decoder input:</span>${tgt}</div>`;
+    this.tokenDisplay.style.display = 'block';
+  }
+
+  // ── SVG Highlight ─────────────────────────────────────────────────────────────
+  _updateArchHighlight(idx) {
+    const step = STEPS[idx];
+    this.archSvg.querySelectorAll('.arch-box, .cross-arrow').forEach(el => {
+      el.classList.remove('active', 'dimmed');
+    });
+
+    if (step.highlightAll) {
+      this.archSvg.querySelectorAll('.arch-box').forEach(el => el.classList.add('active'));
+      return;
+    }
+
+    const active = new Set(step.highlight);
+    this.archSvg.querySelectorAll('.arch-box, .cross-arrow').forEach(el => {
+      if (active.has(el.id)) {
+        el.classList.add('active');
+      } else if (active.size > 0) {
+        el.classList.add('dimmed');
+      }
+    });
+  }
+
+  // ── Heatmaps ──────────────────────────────────────────────────────────────────
+  _updateHeatmaps(idx) {
+    if (!this.trace) return;
+    const step = STEPS[idx];
+
+    if (!step.showHeatmap) {
+      this.heatmapArea.classList.remove('visible');
+      return;
+    }
+    this.heatmapArea.classList.add('visible');
+    this.qkvArea.style.display = 'none';
+
+    const t = step.heatmapTarget;
+
+    if (t === 'enc-embed') {
+      const mat = this.trace.enc.withPosEnc.map(r => Array.from(r));
+      this._renderD3Heatmap(this.attnContainer, mat, {
+        title: 'Embeddings + Positional Encoding  [tokens × d_model]',
+        yLabels: this.srcTokens,
+        colorScheme: 'diverging',
+      });
+
+    } else if (t === 'mha' || t === 'masked-mha' || t === 'cross-mha') {
+      const mhaTrace = resolvePath(this.trace, step.traceKey);
+      if (!mhaTrace || !mhaTrace.heads) return;
+
+      const h        = this.currentHead;
+      const head     = mhaTrace.heads[h];
+      const wMat     = head.weights.map(r => Array.from(r));
+      const isCross  = t === 'cross-mha';
+      const yLabs    = step.isEncoder ? this.srcTokens : this.tgtTokens;
+      const xLabs    = isCross ? this.srcTokens : yLabs;
+
+      this._renderD3Heatmap(this.attnContainer, wMat, {
+        title: `Attention Weights  [${t === 'masked-mha' ? 'causal ' : ''}head ${h}]`,
+        yLabels: yLabs,
+        xLabels: xLabs,
+        colorScheme: 'sequential',
+      });
+
+      this.qkvArea.style.display = 'flex';
+      this._renderD3Heatmap(this.qContainer, head.Q.map(r => Array.from(r)), { title: 'Q  [tokens × d_k]', yLabels: yLabs, colorScheme: 'diverging', cellSize: 5 });
+      this._renderD3Heatmap(this.kContainer, head.K.map(r => Array.from(r)), { title: 'K  [tokens × d_k]', yLabels: xLabs, colorScheme: 'diverging', cellSize: 5 });
+      this._renderD3Heatmap(this.vContainer, head.V.map(r => Array.from(r)), { title: 'V  [tokens × d_v]', yLabels: xLabs, colorScheme: 'diverging', cellSize: 5 });
+
+    } else if (t === 'output-probs') {
+      // Show top-12 vocab tokens for the last decoder position
+      const probs = this.trace.output.probs;
+      const lastRow = Array.from(probs[probs.length - 1]);
+      const top = lastRow.map((p, i) => ({ p, i }))
+                         .sort((a, b) => b.p - a.p)
+                         .slice(0, 12);
+      const mat    = [top.map(x => x.p)];
+      const xLabs  = top.map(x => window.TRANSFORMER_VOCAB[x.i]);
+      this._renderD3Heatmap(this.attnContainer, mat, {
+        title: 'Output Probabilities  [top-12 tokens, last decoder pos]',
+        xLabels: xLabs,
+        colorScheme: 'sequential',
+      });
+    }
+  }
+
+  // ── D3 Heatmap Renderer ───────────────────────────────────────────────────────
+  _renderD3Heatmap(container, matrix, opts = {}) {
+    if (!window.d3 || !matrix || !matrix.length) return;
+    const { title = '', xLabels = [], yLabels = [], colorScheme = 'sequential', cellSize: cs } = opts;
+
+    container.innerHTML = '';
+
+    const rows = matrix.length;
+    const cols = matrix[0].length;
+    const cellSize = cs || Math.min(34, Math.max(7, Math.floor(240 / Math.max(rows, cols))));
+    const margin = {
+      top:    title   ? 22 : 6,
+      right:  8,
+      bottom: xLabels.length ? 56 : 12,
+      left:   yLabels.length ? 54 : 10,
+    };
+    const W = cols * cellSize + margin.left + margin.right;
+    const H = rows * cellSize + margin.top  + margin.bottom;
+
+    const svg = d3.select(container).append('svg').attr('width', W).attr('height', H);
+
+    if (title) {
+      svg.append('text')
+        .attr('x', W / 2).attr('y', 14)
+        .attr('text-anchor', 'middle')
+        .attr('font-size', 10).attr('fill', '#94a3b8').attr('font-family', 'monospace')
+        .text(title);
+    }
+
+    const flat = matrix.flat();
+    const [minV, maxV] = d3.extent(flat);
+    let colorFn;
+    if (colorScheme === 'diverging') {
+      const abs = Math.max(Math.abs(minV), Math.abs(maxV)) || 1;
+      colorFn = d3.scaleDiverging([-abs, 0, abs]).interpolator(d3.interpolateRdBu);
+    } else {
+      colorFn = d3.scaleSequential([minV === maxV ? minV - 1 : minV, maxV])
+                   .interpolator(d3.interpolateYlOrRd);
+    }
+
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
+
+    matrix.forEach((row, i) => {
+      row.forEach((val, j) => {
+        const cell = g.append('rect')
+          .attr('x', j * cellSize).attr('y', i * cellSize)
+          .attr('width', cellSize - 1).attr('height', cellSize - 1)
+          .attr('fill', colorFn(val))
+          .attr('rx', 1);
+        cell.append('title').text(`[${yLabels[i] !== undefined ? yLabels[i] : i}, ${xLabels[j] !== undefined ? xLabels[j] : j}]: ${val.toFixed(4)}`);
+      });
+    });
+
+    // X-axis labels
+    if (xLabels.length) {
+      g.selectAll('.xlbl').data(xLabels).enter()
+        .append('text').attr('class', 'xlbl')
+        .attr('x', (d, i) => i * cellSize + cellSize / 2)
+        .attr('y', rows * cellSize + 10)
+        .attr('transform', (d, i) => `rotate(45,${i * cellSize + cellSize / 2},${rows * cellSize + 10})`)
+        .attr('text-anchor', 'start')
+        .attr('font-size', Math.min(9, cellSize))
+        .attr('fill', '#94a3b8')
+        .text(d => (d + '').length > 7 ? (d + '').slice(0, 7) + '…' : d);
+    }
+
+    // Y-axis labels
+    if (yLabels.length) {
+      g.selectAll('.ylbl').data(yLabels).enter()
+        .append('text').attr('class', 'ylbl')
+        .attr('x', -4).attr('y', (d, i) => i * cellSize + cellSize / 2 + 3)
+        .attr('text-anchor', 'end')
+        .attr('font-size', Math.min(9, cellSize))
+        .attr('fill', '#94a3b8')
+        .text(d => (d + '').length > 7 ? (d + '').slice(0, 7) + '…' : d);
+    }
+  }
+
+  // ── Token Dots ────────────────────────────────────────────────────────────────
+  _createTokenDots() {
+    this.overlay.innerHTML = '';
+    this.tokenDots = [];
+
+    const colors = ['#f97316','#fb923c','#fdba74','#fcd34d','#a3e635','#34d399','#38bdf8','#818cf8'];
+    const n = Math.min(this.srcTokens.length, 8);
+
+    for (let i = 0; i < n; i++) {
+      const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+      g.classList.add('token-dot');
+
+      const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      circle.setAttribute('r', '7');
+      circle.setAttribute('fill', colors[i]);
+      circle.setAttribute('opacity', '0.92');
+
+      const label = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      label.setAttribute('text-anchor', 'middle');
+      label.setAttribute('dominant-baseline', 'middle');
+      label.setAttribute('font-size', '6');
+      label.setAttribute('fill', '#0f172a');
+      label.setAttribute('font-weight', '700');
+      label.setAttribute('pointer-events', 'none');
+      const word = this.srcTokens[i] || '';
+      label.textContent = word.length > 4 ? word.slice(0, 3) + '.' : word;
+
+      g.appendChild(circle);
+      g.appendChild(label);
+      this.overlay.appendChild(g);
+      this.tokenDots.push(g);
+    }
+
+    this._moveDotsToStep(this.currentStep);
+  }
+
+  _moveDotsToStep(idx) {
+    if (!this.tokenDots.length) return;
+    const step = STEPS[idx];
+
+    if (step.highlightAll || !step.highlight.length) {
+      this.tokenDots.forEach(d => d.setAttribute('opacity', '0'));
+      return;
+    }
+
+    const primaryId = step.highlight[0];
+    const center = this.boxCenters[primaryId];
+    if (!center) {
+      // Retry once after layout settles
+      requestAnimationFrame(() => {
+        this._computeBoxCenters();
+        this._moveDotsToStep(idx);
+      });
+      return;
+    }
+
+    const n = this.tokenDots.length;
+    this.tokenDots.forEach((dot, i) => {
+      dot.setAttribute('opacity', '1');
+      const spread = Math.min(n * 13, 90);
+      const ox = (i - (n - 1) / 2) * (n > 1 ? spread / (n - 1) : 0);
+      const oy = (i % 2) * 7 - 3;
+      dot.setAttribute('transform', `translate(${center.x + ox}, ${center.y + oy})`);
+    });
+  }
+}
+
+// ─── Boot ─────────────────────────────────────────────────────────────────────
+document.addEventListener('DOMContentLoaded', () => {
+  window._viz = new VizController();
+});


### PR DESCRIPTION
Self-contained browser app that runs a full encoder-decoder Transformer
forward pass and lets the user step through all 11 stages: tokenization,
embeddings + positional encoding, encoder self-attention (×2 layers),
decoder masked self-attention, cross-attention, FFN, and output softmax.

- transformer.js: pure-JS math engine — seeded weights, matMul, softmax,
  layerNorm, GELU, scaledDotProductAttention, causal mask, ForwardTrace
- viz.js: VizController — STEPS array, D3 attention heatmaps (with Q/K/V
  sub-panels), SVG highlight system, animated token dots, head selector
- style.css: dark theme, CSS variables, arch-box active/dimmed transitions
- index.html: two-column layout + full hand-coded SVG architecture diagram
  (encoder & decoder stacks, residual arrows, cross-attention paths)

Open transformer-viz/index.html directly in any browser (no server needed).

https://claude.ai/code/session_0148U8nFEdbYcCfgQoWmEmG9